### PR TITLE
Make titles of posts link to posts page

### DIFF
--- a/app/[contentType]/[slug]/page.tsx
+++ b/app/[contentType]/[slug]/page.tsx
@@ -36,7 +36,6 @@ const page = async ({ params }: PageProps) => {
     return <div>404 sorry you poor bitdev</div>
   }
 
-  // return <div>{JSON.stringify(post)}</div>
   return (
     <div>
       {params.contentType === contentType && data === undefined ? (

--- a/app/[contentType]/page.tsx
+++ b/app/[contentType]/page.tsx
@@ -1,16 +1,12 @@
-import {
-  ContentType,
-  getSortedMarkdownContent,
-} from '../../lib/parse-markdown-files'
+import { getSortedMarkdownContent } from '../../lib/parse-markdown-files'
 
 import Link from 'next/link'
 import MeetupName from '@/components/MeetupName'
 
 export default function Posts({ params }: { params: any }) {
-  const contentType = params.contentType
+  const { contentType } = params
   const allContentData = getSortedMarkdownContent(contentType)
 
-  console.log(allContentData)
   return (
     <main className="flex min-h-screen flex-col items-center justify-between p-24">
       <MeetupName />
@@ -21,7 +17,7 @@ export default function Posts({ params }: { params: any }) {
       <ul>
         {allContentData.map(({ id, date, title }) => (
           <li className="post" key={id}>
-            {title}
+            <Link href={`/${contentType}/${id}`}>{title}</Link>
             <br />
             {id}
             <br />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -68,14 +68,16 @@ export default function Home({}) {
       <div className="flex flex-col gap-10 py-10">
         <h2 className="text-center">Recent Blog Posts</h2>
 
-        {postsContentData.map(({ id, date, title, author }) => (
+        {postsContentData.map(({ id, date, title }, i) => (
           <PostPreview
             id={id}
             title={title}
             date={date}
             type="posts"
-            author={author}
-            previewText={"Our monthly Socratic Seminar events are formatted to foster debate, information sharing and lively discussion."}
+            previewText={
+              'Our monthly Socratic Seminar events are formatted to foster debate, information sharing and lively discussion.'
+            }
+            key={i}
           />
         ))}
 

--- a/components/PostPreview.tsx
+++ b/components/PostPreview.tsx
@@ -1,23 +1,31 @@
 interface PostPreviewProps {
-    title: string;
-    date?: string;
-    author?: string;
-    previewText: string;
-    type: string;
-    id: string;
+  title: string
+  date?: string
+  author?: string
+  previewText: string
+  type: string
+  id: string
 }
 
-export default function PostPreview(props:PostPreviewProps){
-    return(
-        <article>
-            <header className="flex flex-col gap-1">   
-                <h3>
-                    <a href={"/" + props.type + "/" + props.id} className="no-underline">{props.title}</a>
-                </h3>
-                <time className="font-sans text-gray-500 text-lg order-first">{props.date}</time>
-                {props.author ? <p className="order-last text-xl font-sans">{props.author}</p> : ``}
-            </header>
-            <p>{props.previewText}</p>
-        </article>
-    )
+export default function PostPreview(props: PostPreviewProps) {
+  return (
+    <article>
+      <header className="flex flex-col gap-1">
+        <h3>
+          <a href={'/' + props.type + '/' + props.id} className="no-underline">
+            {props.title}
+          </a>
+        </h3>
+        <time className="font-sans text-gray-500 text-lg order-first">
+          {props.date}
+        </time>
+        {props.author ? (
+          <p className="order-last text-xl font-sans">{props.author}</p>
+        ) : (
+          ``
+        )}
+      </header>
+      <p>{props.previewText}</p>
+    </article>
+  )
 }

--- a/lib/parse-markdown-files.ts
+++ b/lib/parse-markdown-files.ts
@@ -27,7 +27,6 @@ interface MarkdownData {
 }
 
 export function getSortedMarkdownContent(contentType: ContentType) {
-  // console.log(contentType)
   const contentDirectory = path.join(process.cwd(), `/content/${contentType}`)
 
   // Get file names under /posts

--- a/scripts/summarize-md.ts
+++ b/scripts/summarize-md.ts
@@ -1,8 +1,8 @@
-import { OpenAI } from "langchain/llms/openai";
-import { loadSummarizationChain } from "langchain/chains";
-import { RecursiveCharacterTextSplitter } from "langchain/text_splitter";
-import { GithubRepoLoader } from "langchain/document_loaders/web/github";
-import { read, readFileSync } from "fs";
+import { OpenAI } from 'langchain/llms/openai'
+import { loadSummarizationChain } from 'langchain/chains'
+import { RecursiveCharacterTextSplitter } from 'langchain/text_splitter'
+import { GithubRepoLoader } from 'langchain/document_loaders/web/github'
+import { read, readFileSync } from 'fs'
 
 /*
   1. Ingest a markdown file and extract each link.
@@ -10,49 +10,46 @@ import { read, readFileSync } from "fs";
   3. Create sumaries at multiple skill levels for each link ("Detailed", "ELI5")
   4. Create a new markdown file with the summaries.
 */
-const NYC_BITDEVS = 'https://github.com/BitDevsNYC/BitDevsNYC.github.io';
+const NYC_BITDEVS = 'https://github.com/BitDevsNYC/BitDevsNYC.github.io'
 
 const loadFromRepo = async () => {
-  const loader = new GithubRepoLoader(
-    NYC_BITDEVS,
-    { branch: "main", recursive: false, unknown: "warn", ignorePaths: ["*.md"] }
-  );
-  const docs = await loader.load();
-  console.log({ docs });
-
-};
+  const loader = new GithubRepoLoader(NYC_BITDEVS, {
+    branch: 'main',
+    recursive: false,
+    unknown: 'warn',
+    ignorePaths: ['*.md'],
+  })
+  const docs = await loader.load()
+}
 
 /**
  * Ingest a markdown file and extract each link.
  */
 const getLinks = async (markdownPath: string) => {
-  const linksRegex = /\[([^\[]+)\](\(.*\))/gm;
-  const singleMatchRegex = /\[([^\[]+)\]\((.*)\)/;
-  const file = await readFileSync(markdownPath, "utf-8");
-  const matches = file.match(linksRegex) ?? [];
+  const linksRegex = /\[([^\[]+)\](\(.*\))/gm
+  const singleMatchRegex = /\[([^\[]+)\]\((.*)\)/
+  const file = await readFileSync(markdownPath, 'utf-8')
+  const matches = file.match(linksRegex) ?? []
   const links = []
-  console.log(matches);
   for (let i = 0; i < matches.length; i++) {
     const match = singleMatchRegex.exec(matches[i])
-    if (!match) continue;
+    if (!match) continue
     links.push({
       full: match[0],
       title: match[1],
-      link: match[2]
+      link: match[2],
     })
   }
-  return links;
+  return links
 }
 
-export async function summarizeWebpage() { 
-  const model = new OpenAI({ temperature: 0 });
-  const textSplitter = new RecursiveCharacterTextSplitter({ chunkSize: 1000 });
+export async function summarizeWebpage() {
+  const model = new OpenAI({ temperature: 0 })
+  const textSplitter = new RecursiveCharacterTextSplitter({ chunkSize: 1000 })
   // const docs = await textSplitter.createDocuments([text]);
 }
 
-const run = async () => { 
+const run = async () => {
   const links = await getLinks('./_posts/2023-06-28-socratic-seminar-125.md')
-  console.log(links)
-
-};
+}
 run()


### PR DESCRIPTION
Completes issue #35 

@sbddesign, even though you added the navigation links to the `PostPreview` component, we still needed them on `app/[contentType]/page.tsx`. This PR adds those updates.